### PR TITLE
Convert to Swift 3

### DIFF
--- a/LXSemVer.podspec.json
+++ b/LXSemVer.podspec.json
@@ -1,6 +1,6 @@
 {
 	"name": "LXSemVer",
-	"version": "1.2.0",
+	"version": "2.0.0",
 	"license": "MIT",
 	"authors": {
 		"Stan Chang Khin Boon": "stan@trifia.com"
@@ -8,7 +8,7 @@
 	"homepage": "https://github.com/trifia/LXSemVer",
 	"source": {
 		"git": "https://github.com/trifia/LXSemVer.git",
-		"tag": "1.2.0"
+		"tag": "2.0.0"
 	},
 	"summary": "Swift Semantic Versioning 2.0.0 model and parser.",
 	"platforms": {

--- a/LXSemVer.xcodeproj/project.pbxproj
+++ b/LXSemVer.xcodeproj/project.pbxproj
@@ -268,14 +268,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = lxcid;
 				TargetAttributes = {
 					AB0D1FE21BD6E644003971A3 = {
 						CreatedOnToolsVersion = 7.0.1;
+						LastSwiftMigration = 0820;
 					};
 					AB0D1FEC1BD6E644003971A3 = {
 						CreatedOnToolsVersion = 7.0.1;
+						LastSwiftMigration = 0820;
 					};
 					AB9C2A991BD8247B00729B33 = {
 						CreatedOnToolsVersion = 7.0.1;
@@ -402,8 +404,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -450,8 +454,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -471,6 +477,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -482,6 +489,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -493,6 +501,7 @@
 				PRODUCT_NAME = LXSemVer;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -500,6 +509,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -510,6 +520,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.lxcid.LXSemVer.iOS;
 				PRODUCT_NAME = LXSemVer;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -520,6 +531,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lxcid.LXSemVerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -530,6 +542,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.lxcid.LXSemVerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/LXSemVer.xcodeproj/xcshareddata/xcschemes/LXSemVer_OSX.xcscheme
+++ b/LXSemVer.xcodeproj/xcshareddata/xcschemes/LXSemVer_OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/LXSemVer.xcodeproj/xcshareddata/xcschemes/LXSemVer_iOS.xcscheme
+++ b/LXSemVer.xcodeproj/xcshareddata/xcschemes/LXSemVer_iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@
 ### CocoaPods
 
 ```ruby
-pod "LXSemVer", "~> 1.0"
+pod "LXSemVer", "~> 2.0"
 ```
 
 ### Carthage
 
 ```
-github "lxcid/LXSemVer" ~> 1.0
+github "lxcid/LXSemVer" ~> 2.0
 ```
 
 ## Usage
@@ -48,6 +48,10 @@ import LXSemVer
 let version: Version = "1.0.1-alpha.1"
 print(version.next())
 ```
+
+## Compatibility
+
+`LXSemVer` 2.0 uses Swift 3.1. For projects using Swift 2.2 or older, please use `LXSemVer` 1.2.
 
 ## Concept
 

--- a/Sources/DotSeparatedValues.swift
+++ b/Sources/DotSeparatedValues.swift
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-func isValidValue(characters: String.CharacterView) -> Bool {
+func isValidValue(_ characters: String.CharacterView) -> Bool {
     if characters.isEmpty {
         return false
     }
@@ -38,7 +38,7 @@ func isValidValue(characters: String.CharacterView) -> Bool {
         }
     }
     if isNumeric && characters.count > 1 {
-        guard let firstCharacter = characters.first where firstCharacter != "0" else {
+        guard let firstCharacter = characters.first, firstCharacter != "0" else {
             return false
         }
     }
@@ -49,7 +49,7 @@ public struct DotSeparatedValues {
     public let values: [String]
     
     public init?(characters: String.CharacterView) {
-        let values = characters.split(".", maxSplit: Int.max, allowEmptySlices: true)
+        let values = characters.split(separator: ".", maxSplits: Int.max, omittingEmptySubsequences: false)
         assert(!values.isEmpty)
         for value in values {
             if !isValidValue(value) {
@@ -88,7 +88,7 @@ public func <(lhs: DotSeparatedValues, rhs: DotSeparatedValues) -> Bool {
         }
         let lnumOpt = Int(lvalue)
         let rnumOpt = Int(rvalue)
-        if let lnum = lnumOpt, let rnum = rnumOpt where lnum < rnum {
+        if let lnum = lnumOpt, let rnum = rnumOpt, lnum < rnum {
             return true
         } else if lnumOpt == nil && rnumOpt == nil && lvalue < rvalue {
             return true
@@ -101,13 +101,13 @@ public func <(lhs: DotSeparatedValues, rhs: DotSeparatedValues) -> Bool {
     return lhs.values.count < rhs.values.count
 }
 
-extension DotSeparatedValues : ArrayLiteralConvertible {
+extension DotSeparatedValues : ExpressibleByArrayLiteral {
     public init(arrayLiteral elements: String...) {
         self.init(values: elements)!
     }
 }
 
-extension DotSeparatedValues : StringLiteralConvertible {
+extension DotSeparatedValues : ExpressibleByStringLiteral {
     public init(unicodeScalarLiteral value: String) {
         self.init(string: value)!
     }
@@ -123,14 +123,14 @@ extension DotSeparatedValues : StringLiteralConvertible {
 
 extension DotSeparatedValues : CustomStringConvertible {
     public var description: String {
-        return self.values.joinWithSeparator(".")
+        return self.values.joined(separator: ".")
     }
 }
 
 extension DotSeparatedValues {
     public func next() -> [DotSeparatedValues] {
         var result = [DotSeparatedValues]()
-        for (index, value) in self.values.enumerate() {
+        for (index, value) in self.values.enumerated() {
             if let num = Int(value) {
                 var valueSlice = self.values[0...index]
                 valueSlice[index] = String(num + 1)

--- a/Tests/LXSemVerTests.swift
+++ b/Tests/LXSemVerTests.swift
@@ -10,16 +10,16 @@ import XCTest
 @testable import LXSemVer
 
 // http://stackoverflow.com/a/24029847
-extension CollectionType {
+extension Collection {
     /// Return a copy of `self` with its elements shuffled
-    func shuffle() -> [Generator.Element] {
+    func shuffle() -> [Iterator.Element] {
         var list = Array(self)
         list.shuffleInPlace()
         return list
     }
 }
 
-extension MutableCollectionType where Index == Int {
+extension MutableCollection where Index == Int {
     /// Shuffle the elements of `self` in-place.
     mutating func shuffleInPlace() {
         // empty and single-element collections don't shuffle
@@ -33,8 +33,8 @@ extension MutableCollectionType where Index == Int {
     }
 }
 
-private func hasMatch(string: String, regex: NSRegularExpression) -> Bool {
-    let numberOfMatches = regex.numberOfMatchesInString(string, options: [], range: NSMakeRange(0, string.characters.count))
+private func hasMatch(_ string: String, regex: NSRegularExpression) -> Bool {
+    let numberOfMatches = regex.numberOfMatches(in: string, options: [], range: NSMakeRange(0, string.characters.count))
     return numberOfMatches > 0
 }
 
@@ -165,7 +165,7 @@ class VersionTests: XCTestCase {
                 "2.1.0",
                 "2.1.1",
             ]
-            XCTAssertEqual(versions.shuffle().sort(<), versions)
+            XCTAssertEqual(versions.shuffle().sorted(by: <), versions)
         }
         
         XCTAssert(Version(stringLiteral: "1.0.0-alpha") < Version(stringLiteral: "1.0.0"))
@@ -189,7 +189,7 @@ class VersionTests: XCTestCase {
                 "1.0.0-rc.1",
                 "1.0.0",
             ]
-            XCTAssertEqual(versions.shuffle().sort(<), versions)
+            XCTAssertEqual(versions.shuffle().sorted(by: <), versions)
         }
     }
     


### PR DESCRIPTION
Hey! I really liked this library, it seems to be the best semver parsing swift lib around currently. I noticed that it didn't support Swift 3, so I updated it and added Xcode recommended build defaults.

Unfortunately this means that we need a major version bump, since Swift 3 introduces backwards-incompatible changes. I've updated the podspec, but this will need a new git tag and a cocoapods push after merging.

Happy to discuss these changes or implement feedback as well!