### PR TITLE
Allow to use version with less than three components

### DIFF
--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -55,10 +55,10 @@ public struct Version {
         
         let versionEndIndex = prereleaseStartIndex ?? buildMetadataStartIndex ?? characters.endIndex
         let versionCharacters = characters.prefix(upTo: versionEndIndex)
-        let versionComponents = versionCharacters.split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false).flatMap(versionComponentFromCharacters)
+        var versionComponents = versionCharacters.split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false).flatMap(versionComponentFromCharacters)
         
-        guard versionComponents.count == 3 else {
-            return nil
+        while versionComponents.count < 3 {
+            versionComponents.append(0)
         }
         
         var prerelease: DotSeparatedValues? = nil


### PR DESCRIPTION
Allow users to create version like **2** or **2.4** by adding 0's till arriving the three needed version components.