### PR TITLE
Allow version with less than three components

### DIFF
--- a/Sources/Version.swift
+++ b/Sources/Version.swift
@@ -21,11 +21,9 @@
 // SOFTWARE.
 
 func versionComponentFromCharacters(_ characters: Substring) -> UInt? {
-    var component: UInt? = nil
+    var component: UInt?
     if characters.count > 0 {
-        if let firstCharacter = characters.first, firstCharacter != "0" || characters.count == 1 {
-            component = UInt(String(characters))
-        }
+        component = UInt(characters)
     }
 
     return component
@@ -53,10 +51,14 @@ public struct Version {
 
         let versionEndIndex = prereleaseStartIndex ?? buildMetadataStartIndex ?? string.endIndex
         let versionCharacters = string.prefix(upTo: versionEndIndex)
-        var versionComponents = versionCharacters.split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false).compactMap(versionComponentFromCharacters)
-
-        guard versionComponents.count == 3 else {
+        guard versionCharacters.count > 0, versionCharacters.last != "." else {
+            // If a negative number is present in version components, version characters will be empty or will finish with a dot
             return nil
+        }
+
+        var versionComponents = versionCharacters.split(separator: ".", maxSplits: 2, omittingEmptySubsequences: false).compactMap(versionComponentFromCharacters)
+        while versionComponents.count < 3 {
+            versionComponents.append(0)
         }
 
         var prerelease: DotSeparatedValues?

--- a/Tests/LXSemVerTests.swift
+++ b/Tests/LXSemVerTests.swift
@@ -142,11 +142,24 @@ class VersionTests: XCTestCase {
         XCTAssertEqual(UInt("1")!, 1)
         
         XCTAssertNotNil(Version(string: "1.0.0"))
-        XCTAssertNil(Version(string: "01.0.0"))
+        XCTAssertNotNil(Version(string: "01.0.0"))
+        XCTAssertEqual(Version(string: "1.0.0"), Version(string: "01.0.0"))
+
         XCTAssertNotNil(Version(string: "1.5.0"))
-        XCTAssertNil(Version(string: "1.05.0"))
+        XCTAssertNotNil(Version(string: "1.05.0"))
+        XCTAssertEqual(Version(string: "1.5.0"), Version(string: "1.05.0"))
+
         XCTAssertNotNil(Version(string: "0.1.7"))
-        XCTAssertNil(Version(string: "0.1.007"))
+        XCTAssertNotNil(Version(string: "0.1.007"))
+        XCTAssertEqual(Version(string: "0.1.7"), Version(string: "0.1.007"))
+
+        XCTAssertNil(Version(string: ""))
+
+        XCTAssertNotNil(Version(string: "1.29"))
+        XCTAssertEqual(Version(string: "1.29"), Version(string: "1.29.0"))
+
+        XCTAssertNotNil(Version(string: "1"))
+        XCTAssertEqual(Version(string: "1"), Version(string: "1.0.0"))
         
         XCTAssertNotNil(Version(string: "1.1.1"))
         XCTAssertNil(Version(string: "-1.1.1"))


### PR DESCRIPTION
Allow users to create version like **2** or **2.4** by adding 0's till arriving the three needed version components.

I've also added support for versions like **1.05.0** converting them to **1.5.0**.